### PR TITLE
Make build timestamp changes work on Solaris (#3324) (#3329)

### DIFF
--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -276,21 +276,13 @@ configureVersionStringParameter() {
     buildTimestamp="${buildTimestamp//Z/}"
   else
     # Get current ISO-8601 datetime
-    if isGnuCompatDate; then
-      buildTimestamp=$(date --utc +"%Y-%m-%d %H:%M:%S")
-    else
-      buildTimestamp=$(date -u -j +"%Y-%m-%d %H:%M:%S") 
-    fi
+    buildTimestamp=$(date -u +"%Y-%m-%d %H:%M:%S") 
   fi
   BUILD_CONFIG[BUILD_TIMESTAMP]="${buildTimestamp}"
 
   # Convert ISO-8601 buildTimestamp string to dateSuffix format: %Y%m%d%H%M
-  local dateSuffix
-  if isGnuCompatDate; then
-    dateSuffix=$(date --utc --date="${buildTimestamp}" +"%Y%m%d%H%M")
-  else
-    dateSuffix=$(date -u -j -f "%Y-%m-%d %H:%M:%S" "${buildTimestamp}" +"%Y%m%d%H%M")
-  fi
+  # "%Y-%m-%d %H:%M:%S" to "%Y%m%d%H%M"
+  local dateSuffix=$(echo "${buildTimestamp}" | cut -d":" -f1-2 | tr -d ": -")
 
   # Configures "vendor" jdk properties.
   # Temurin default values are set after this code block


### PR DESCRIPTION
* Make build timestamp changes work on Solaris



* Make build timestamp changes work on Solaris



* Update sbin/build.sh



* Make build timestamp changes work on Solaris



---------

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
- [ ] I have read the [Code of Conduct](https://github.com/danopstech/.github/blob/main/CODE_OF_CONDUCT.md)
- [ ] I have updated the documentation accordingly.
- [ ] All commits are GPG signed
