### PR TITLE
Fix mk-cacerts.sh Solaris sed failure and escaped subject commas (#34…

### DIFF
--- a/security/mk-cacerts.sh
+++ b/security/mk-cacerts.sh
@@ -84,7 +84,8 @@ alreadyExistsCounter=0 # counter for duplicated file
 
 for FILE in certs/*.crt; do
     # Use rfc2253 standard format, so output format is deterministic
-    ALIAS_FROM_SUBJECT=$(openssl x509 -subject -noout -nameopt rfc2253 -in "$FILE" | sed 's/^subject=[[:space:]]*//' | tr ' ' '_')
+    # Translate spaces and escaped commas(\,) to underscore
+    ALIAS_FROM_SUBJECT=$(openssl x509 -subject -noout -nameopt rfc2253 -in "$FILE" | sed 's/^subject= *//' | tr ' ' '_' | sed 's/\\\,/_/g')
     echo "Subject: ${ALIAS_FROM_SUBJECT}"
 
     # Create ALIAS from widely recognised standard DN's


### PR DESCRIPTION
…19) (#3421)

* Fix mk-cacerts.sh Solaris sed failure and escaped subject commas



* Fix mk-cacerts.sh Solaris sed failure and escaped subject commas



---------

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
- [ ] I have read the [Code of Conduct](https://github.com/danopstech/.github/blob/main/CODE_OF_CONDUCT.md)
- [ ] I have updated the documentation accordingly.
- [ ] All commits are GPG signed
